### PR TITLE
[chapter2 / 라도] 이펙티브 타입스크립트 아이템 9~18 내용 요약

### DIFF
--- a/chapter2/lado/item12-14.md
+++ b/chapter2/lado/item12-14.md
@@ -1,0 +1,384 @@
+# 이펙티브 타입스크립트 아이템 12~14
+
+## 아이템 12. 함수 표현식에 타입 적용하기
+
+- 타입스크립트에서는 함수 표현식을 사용하는 것이 좋다. 함수의 매개변수부터 반환값까지 전체를 함수 타입으로 선언하여 함수 표현식에 재사용할 수 있다는 장점이 있기 때문이다.
+
+  ```tsx
+  function rollDice(sides: number): number {
+    /* ... */
+  } // 문장
+  const rollDice2 = function (sides: number): numberg {
+    /* ... */
+  } // 표현식
+  const rollDice3 = (sides: number): number => {
+    /* ... */
+  } // 표현식
+
+  type DiceRollFn = (sides: number) => number
+  const rollDice: DiceRollFn = (sides) => {
+    /* ... */
+  }
+  ```
+
+- 함수 타입 선언의 장점
+
+  - 불필요한 코드의 반복을 줄인다.
+  - 함수 구현부가 분리되어 있어 로직이 보다 분명해진다.
+
+    ```tsx
+    function add(a: number, b: number) {
+      return a + b
+    }
+    function sub(a: number, b: number) {
+      return a - b
+    }
+    function mul(a: number, b: number) {
+      return a * b
+    }
+    function div(a: number, b: number) {
+      return a / b
+    }
+
+    type BinaryFn = (a: number, b: number) => number
+    const add: BinaryFn = (a, b) => a + b
+    const sub: BinaryFn = (a, b) => a - b
+    const mul: BinaryFn = (a, b) => a * b
+    const div: BinaryFn = (a, b) => a / b
+    ```
+
+- 시그니처가 일치하는 다른 함수가 있을 때도 함수 표현식에 타입을 적용하면 좋다.
+
+  ```tsx
+  const responseP = fetch('/quote?by=Mark+Twain') // 타입은 Promise<Response>
+
+  async function getQuote() {
+    const response = await fetch('/quote?by=Mark+Than')
+    const quote = await response.json()
+    return quote
+  }
+
+  // {
+  //      "quote": "If you tell the truth, you don't have to remember anything.",
+  //      "source": "notebook",
+  //      "date": "1984"
+  // }
+
+  // lib.dom.d.ts에 있는 fetch의 타입 선언
+  declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>
+
+  async function checkedFetch1(input: RequestInfo, init?: RequestInit) {
+    const response = await fetch(input, init)
+    if (!response.ok) {
+      // 비동기 함수 내에서 거절된 프로미스로 변환합니다.
+      throw new Error('Request failed: ' + response.status)
+    }
+    return response
+  }
+
+  // typeof fn을 사용해 fetch 함수의 시그니처 참조
+  const checkedFetch2: typeof fetch = async (input, init) => {
+    const response = await fetch(input, init)
+    if (!response.ok) {
+      throw new Error('Request failed: ' + response.status)
+    }
+    return response
+  }
+
+  // throw를 return으로 잘못 기재했을 때 타입 오류를 잡아냄
+  const checkedFetch3: typeof fetch = async (input, init) => {
+    // Type '(input: RequestInfo, init: RequestInit | undefined) => Promise<Response | Error>' is not assignable to type '{ (input: RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: RequestInfo, init?: RequestInit | undefined): Promise<...>; }'.
+    // Type 'Promise<Response | Error>' is not assignable to type 'Promise<Response>'.
+    // Type 'Response | Error' is not assignable to type 'Response'.
+    // Type 'Error' is missing the following properties from type 'Response': headers, ok, redirected, status, and 11 more.
+    const response = await fetch(input, init)
+    if (!response.ok) {
+      return new Error('Request failed: ' + response.status)
+    }
+    return response
+  }
+  ```
+
+  <br />
+
+## 아이템 13. 타입과 인터페이스의 차이점 알기
+
+- 타입스크립트에서 명명된 타입을 정의하는 방법은 두가지가 있다. 대부분의 경우에는 타입을 사용해도 되고 인터페이스를 사용해도 된다.
+
+```tsx
+type TState = {
+  name: string
+  capital: string
+}
+
+interface IState {
+  name: string
+  capital: string
+}
+```
+
+- (cf) 인터페이스 접두사로 I를 붙이는 것은 C#에서 비롯된 관례로, 지양해야 할 스타일이다.
+- 인터페이스 선언과 타입 선언의 비슷한 점
+
+  - 추가 속성과 함께 할당한다면 동일한 오류가 발생한다.
+
+  ```tsx
+  const wyoming: TState = {
+    name: 'Wyoming',
+    capital: 'Cheyenne',
+    population: 500_000,
+    // Type '{ name: string; capital: string; population: number; }' is not assignable to type 'TState'.
+    // Object literal may only specify known properties, and 'population' does not exist in type 'TState'.
+  }
+  ```
+
+  - 인덱스 시그니처는 인터페이스와 타입에서 모두 사용할 수 있다.
+
+  ```tsx
+  type TDict = { [key: string]: string }
+  interface IDict {
+    [key: string]: string
+  }
+  ```
+
+  - 함수 타입도 인터페이스나 타입으로 정의할 수 있다.
+
+  ```tsx
+  // 함수 타입에 추가적인 속성이 있을 때
+  type TFnWithProperties = {
+    (x: number): number
+    prop: string
+  }
+
+  interface IFnWithProperties {
+    (x: number): number
+    prop: string
+  }
+  ```
+
+  - 제너릭이 가능하다.
+
+  ```tsx
+  type TPair<T> = {
+  	first: T;
+  	second: T;
+  }
+
+  interface IPair<T> = {
+  	first: T;
+  	second: T;
+  }
+  ```
+
+  - 클래스를 구현할 때, 타입과 인터페이스 둘 다 사용할 수 있다.
+
+  ```tsx
+  class StateT implements TState {
+    name: string = ''
+    capital: string = ''
+  }
+
+  class StateI implements IState {
+    name: string = ''
+    capital: string = ''
+  }
+  ```
+
+  - 인터페이스는 타입을 확장할 수 있으며, 타입은 인터페이스를 확장할 수 있다.
+
+  ```tsx
+  interface IStateWithPop extends TState {
+    population: number
+  }
+
+  type TStateWithPop = IState & { population: number }
+
+  // 인터페이스는 유니온 타입 같은 복잡한 타입을 확장하지는 못한다.
+  // 복잡한 타입을 확장하고 싶다면 타입과 &를 사용해야 한다.
+  ```
+
+- 인터페이스 선언과 타입 선언의 차이점
+
+  - 유니온 타입은 있지만 유니온 인터페이스라는 개념은 없다.
+  - 인터페이스는 타입을 확장할 수 있지만, 유니온은 할 수 없다.
+    - 유니온 타입을 확장하는 게 필요한 경우
+    ```tsx
+    type Input = {
+      /* ... */
+    }
+    type Output = {
+      /* ... */
+    }
+    interface VariableMap {
+      [name: string]: Input | Output
+    }
+    ```
+  - 유니온 타입에 name 속성을 붙인 타입도 만들 수 있다.
+
+  ```tsx
+  type NamedVariable = (Input | Output) & { name: string }
+  ```
+
+  - type 키워드는 유니온이 될 수도 있고, 매핑된 타입 또는 조건부 타입 같은 고급 기능에 활용되기도 한다.
+  - 튜플과 배열 타입도 type 키워드를 이용해 더 간결하게 표현할 수 있다.
+
+  ```tsx
+  type Pair = [number, number]
+  type StringList = string[]
+  type NamedNums = [string, ...number[]]
+
+  // 인터페이스로 튜플과 비슷하게 구현할 수 있다. 하지만 그러면 튜플에서 사용할 수 있는 concat과 같은 메서드를 사용할 수 없다.
+  interface Tuple {
+    0: number
+    1: number
+    length: 2
+  }
+  ```
+
+  - 인터페이스는 보강(augment)이 가능하다.
+    - 선언 병합은 주로 타입 선언 파일에서 사용된다. 따라서 타입 선언 파일을 작성할 때는 선언 병합을 지원하기 위해 반드시 인터페이스를 사용해야 하며 표준을 따라야 한다.
+
+  ```tsx
+  // 선언 병합: 속성을 확장하는 것
+  interface IState {
+    name: string
+    capital: string
+  }
+
+  interface IState {
+    population: number
+  }
+
+  const wyoming: IState = {
+    name: 'Wyoming',
+    capital: 'Cheyenne',
+    population: 500_000,
+  } // 정상
+  ```
+
+- 타입과 인터페이스 중 어느 것을 사용해야 할까?
+
+  - 복잡한 타입이라면 타입 별칭
+  - 타입과 인터페이스, 두 가지 방법으로 모두 표현할 수 있는 간단한 객체 타입이라면 일관성과 보강의 관점에서 고려해 봐야 한다.
+  - 향후에 보강의 가능성이 있을지 생각해보고, 어떤 API에 대한 타입 선언을 작성해야 한다면 인터페이스를 사용하는 게 좋다. API가 변경될 때 사용자가 인터페이스를 통해 새로운 필드를 병합할 수 있어 유용하기 때문이다. 그러나 프로젝트 내부적으로 사용되는 타입에 선언 병합이 발생하는 것은 잘못된 설계이다.
+
+  <br />
+
+## 아이템 14. 타입 연산과 제너릭 사용으로 반복 줄이기
+
+- 더 큰 집합을 인덱싱해서 속성의 타입에서 중복 제거하기
+
+```tsx
+type TopNavState = {
+  userId: State['userId']
+  pageTitle: State['pageTitle']
+  recentFiles: State['recentFiles']
+}
+```
+
+- ‘매핑된 타입’을 사용해 중복 제거
+
+```tsx
+type TopNavState = {
+  [k in 'userId' | 'pageTitle' | 'recentFiles']: State[k]
+}
+
+type Pick<T, K> = {
+  [k in K]: T[K]
+}
+
+type TopNavState = Pick<State, 'userId' | 'pageTitle' | 'recentFiles'>
+```
+
+- 매핑된 타입과 keyof 사용해 선택적 필드로 바꾸기
+
+```tsx
+interface Options {
+  width: number
+  height: number
+  color: string
+  label: string
+}
+
+type OptionsUpdate = { [k in keyof Options]?: Options[k] }
+
+/*
+	interface OptionsUpdate {
+	 	width?: number;
+	 	height?: number;
+	 	color?: string;
+	 	label?: string;
+	}
+*/
+
+type OptionsKeys = keyof Options
+// 타입이 "width" | "height" | "color" | "label"
+
+type Partial<T> = {
+  [P in keyof T]?: T[P]
+}
+```
+
+- 값의 형태에 해당하는 타입을 정의하고 싶을 때
+  - 값으로부터 타입을 만들어 낼 때는 선언의 순서에 주의해야 한다. 타입 정의를 먼저하고 값이 그 타입에 할당 가능하다고 선언하는 것이 좋다. 그렇게 해야 타입이 더 명확해지고, 예상하기 어려운 타입 변동을 방지할 수 있다.
+
+```tsx
+const INIT_OPTIONS = {
+  width: 640,
+  height: 480,
+  color: '#00FF00',
+  label: 'VGA',
+}
+
+type Options = typeof INIT_OPTIONS
+
+/*
+	interface Options {
+		width: number;
+		height: number;
+		color: string;
+		label: string;
+	}
+*/
+```
+
+- 함수나 메서드의 반환 값에 명명된 타입을 만들고 싶을 때
+
+```tsx
+function getUserInfo(userId: string) {
+  // ...
+  return {
+    userId,
+    name,
+    // ...
+  }
+}
+
+type UserInfo = ReturnType<typeof getUserInfo>
+```
+
+- 제너릭 타입에서 매개변수를 제한할 수 있는 방법
+
+  - extends 사용
+
+  ```tsx
+  interface Name {
+    first: string
+    last: string
+  }
+
+  type DancingDuo<T extends Name> = [T, T]
+
+  const couple: DancingDuo<Name> = [
+    { first: 'Fred', last: 'Astaire' },
+    { first: 'Ginger', last: 'Rogers' },
+  ]
+  ```
+
+  - Pick의 정의에서 타입 좁히기
+
+  ```tsx
+  type Pick<T, K extends keyof T> = {
+    [k in K]: T[K]
+  }
+  ```

--- a/chapter2/lado/item15-18.md
+++ b/chapter2/lado/item15-18.md
@@ -1,0 +1,190 @@
+## 아이템 15. 동적 데이터에 인덱스 시그니처 사용하기
+
+- 인덱스 시그니처
+  - 동적 데이터를 표현할 때 사용
+  ```tsx
+  type Rocket = { [property: string]: string }
+  const rocket: Rocket = {
+    name: 'Falcon 9',
+    variant: 'v1.0',
+    thrust: '4,940 kN',
+  } // 정상
+  ```
+  - 키의 이름 `property`
+    - 키의 위치만 표시하는 용도. 타입 체커에서는 사용하지 않음.
+  - 키의 타입 `string`
+    - string이나 number 또는 symbol의 조합이어야 하지만, 보통은 string을 사용.
+  - 값의 타입 `string`
+    - 어떤 것이든 될 수 있음.
+- 인덱스 시그니처의 4가지 단점
+  - 잘못된 키를 포함해 모든 키를 허용한다. 오타를 잡을 수 없다.
+  - 객체 안에 프로퍼티가 하나도 없는 {}도 유효한 타입이 된다.
+  - 키마다 다른 타입을 가질 수 없고, 키들의 타입이 통일되어야 한다.
+  - 키를 입력할 때 키에는 어떤 값도 들어올 수 있으므로 자동 완성 기능이 동작하지 않는다.
+- 인덱스 시그니처 대신 사용 가능한 2가지 대안
+  - `Record<K, T>`
+    - 키 타입에 유연성을 제공하는 제너릭 타입
+    ```tsx
+    type Vec3D = Record<'x' | 'y' | 'z', number>
+    // type Vec3D = Record<키에 들어올 수 있는 타입, 값의 타입>;
+    // Type Vec3D = {
+    //		x: number;
+    //		y: number;
+    //		z: number;
+    // }
+    ```
+    - 인덱스 시그니처의 파라미터 타입은 리터럴이 될 수 없다.
+    ```tsx
+    type fruitInfo = {
+      [fruit: '사과' | '딸기' | '포도']: number
+    }
+    // An index signature parameter type cannot be a literal type or generic type. Consider using a mapped object type instead.
+    ```
+  - 매핑된 타입 사용
+    - 키마다 별도의 타입을 사용하게 해준다.
+    ```tsx
+    type ABC = { [k in 'a' | 'b' | 'c']: k extends 'b' ? string : number }
+    // Type ABC = {
+    //     a: number;
+    //     b: string;
+    //     c: number;
+    // }
+    ```
+- 런타임 때까지 객체의 속성을 알 수 없을 경우에만(예를 들어 CSV 파일에서 로드하는 경우) 인덱스 시그니처를 사용하도록 한다.
+- 안전한 접근을 위해 인덱스 시그니처의 값 타입에 undefined를 추가하는 것을 고려해야 한다.
+- 어떤 타입에 가능한 필드가 제한되어 있는 경우라면 인덱스 시그니처로 모델링하지 말아야 한다.
+  ```tsx
+  interface Row1 {
+    [column: string]: number
+  } // 너무 광범위
+  interface Row2 {
+    a: number
+    b?: number
+    c?: number
+    d?: number
+  } // 최선
+  type Row3 =
+    | { a: number }
+    | { a: number; b: number }
+    | { a: number; b: number; c: number }
+    | { a: number; b: number; c: number; d: number } // 가장 정확하지만 사용하기 번거로움
+  ```
+- 연관 배열(associative array)의 경우, 객체에 인덱스 시그니처를 사용하는 대신 Map 타입을 사용하는 것을 고려할 수 있다. ← 잘 이해는 안되지만 298페이지에 관련 내용 나온다고 함.
+
+<br />
+
+## 아이템 16. number 인덱스 시그니처보다는 Array, 튜플, ArrayLike를 사용하기
+
+- 자바스크립트의 이상한 동작(feat. 암시적 타입 강제)
+  - 배열은 객체이므로 키는 숫자가 아니라 문자열이다.
+  - 자바스크립트에서는 숫자나 복잡한 객체를 키로 사용하려고 하면 문자열로 변환해 버린다.
+  - 배열에서 특정 요소를 접근할 때 인덱스를 문자열로 적어도 가능. 배열의 키를 Object.keys로 나열해보면 문자열로 출력된다.
+- 타입스크립트는 암시적 타입 강제의 혼란을 바로잡기 위해 숫자 키를 허용하고, 문자열 키와 다른 것으로 인식한다. (런타입에서는 문자열 키로 인식)
+- 인덱스를 신경 쓰지 않는다면, 배열을 순회할 때 `for...in` 보다 `for...of` 를 써라. 인덱스가 중요하다면 `forEach` 를 써라.
+
+  ```tsx
+  const xs = [1, 2, 3]
+
+  const keys = Object.keys(xs) // 타입이 stirng[]
+  for (const key in xs) {
+    key // 타입이 string
+    const x = xs[key] // 타입이 number
+  }
+
+  for (const x of xs) {
+    x // 타입이 number
+  }
+
+  xs.forEach((x, i) => {
+    i // 타입이 number
+    x // 타입이 number
+  })
+  ```
+
+  - `for...in` 은 `for...of` 나 `for` 루프보다 몇 배나 느리다.
+
+- 인덱스 시그니처에 number를 사용하기 보다 Array, 튜플, ArrayLike 타입을 사용하는 것이 좋다.
+- 어떤 길이를 가지는 배열과 비슷한 형태의 튜플을 사용하고 싶다면 타입스크립트에 있는 ArrayLike 타입을 사용한다.
+  ```tsx
+  const tupleLike: ArrayLike<string> = {
+    '0': 'A',
+    '1': 'B',
+    length: 2,
+  }
+  ```
+
+<br />
+
+## 아이템 17. 변경 관련된 오류 방지를 위해 readonly 사용하기
+
+- `readonly number[]` 와 `number[]` 가 구분되는 특징
+  - 배열의 요소를 읽을 수 있지만, 쓸 수는 없다.
+  - length를 읽을 수 있지만, 바꿀 수는 없다.
+  - 배열을 변경하는 pop을 비롯한 다른 메서드를 호출할 수 없다.
+  - `number[]` 는 `readonly number[]` 보다 기능이 많기 때문에 `readonly number[]` 의 서브 타입이 된다.
+- 매개변수를 readonly로 선언하면 아래와 같은 일이 생긴다.
+  - 타입스크립트는 매개변수가 함수 내에서 변경이 일어나는지 체크한다.
+  - 호출하는 쪽에서는 함수가 매개변수를 변경하지 않는다는 보장을 받게 된다.
+  - 호출하는 쪽에서 함수에 readonly 배열을 매개변수로 넣을 수도 있다.
+- 매개변수를 readonly로 선언할 때의 장점
+  - 더 넓은 타입으로 호출할 수 있고, 의도치 않은 변경은 방지될 것이다.
+  - 지역 변수와 관련된 모든 종류의 변경 오류를 방지할 수 있고, 변경이 발생하는 코드도 쉽게 찾을 수 있다.
+  - 함수가 매개변수를 수정하지 않는다면 readonly로 선언하는 것이 좋다. readonly 매개변수는 인터페이스를 명확하게 하며, 매개변수가 변경되는 것을 방지한다.
+- 단점?
+  - 어떤 함수를 readonly로 만들면 그 함수를 호출하는 다른 함수도 모두 readonly로 만들어야 한다. 다른 라이브러리에 있는 함수를 호출하는 경우라면 타입 선언을 바꿀 수 없기 때문에 타입 단언문을 사용해야 한다.
+- readonly, Readonly 제너릭은 얕게 동작한다는 것에 유의하며 사용해야 한다.
+
+  ```tsx
+  interface Outer {
+    inner: {
+      x: number
+    }
+  }
+
+  const o: Readonly<Outer> = { inner: { x: 0 } }
+  o.inner = { x: 1 }
+  // Cannot assign to 'inner' because it is a read-only property.
+  o.inner.x = 1
+
+  type T = Readonly<Outer>
+  // type T = {
+  //     readonly inner: {
+  //         x: number;
+  //     };
+  // }
+  ```
+
+- 깊은 readonly 타입을 쓰고 싶으면 ts-essentials에 있는 DeepReadonly 제너릭을 사용하면 된다.
+- 인덱스 시그니처에도 readonly를 쓸 수 있다. 일기는 허용하되 쓰기를 방지하는 효과가 있다.
+  ```tsx
+  let obj: { readonly [k: string]: number } = {}
+  // 또는 Readonly<{[k: string]: number}>
+  obj.hi = 45
+  // Index signature in type '{ readonly [k: string]: number; }' only permits reading.
+  obj = { ...obj, hi: 12 }
+  ```
+
+<br />
+
+## 아이템 18. 매핑된 타입을 사용하여 값을 동기화하기
+
+- 어떤 인터페이스에 속성이 추가될 때마다 다른 인터페이스의 속성도 같이 추가되어야 한다고 할 때 매핑된 타입을 사용해 값을 동기화하는 방식을 쓰는 것이 좋다.
+
+```tsx
+interface ScatterProps {
+  xs: number[]
+  ys: number[]
+  color: string
+  onClick: () => void
+  onDoubleClick: () => void
+}
+
+const REQUIRES_UPDATE: { [k in keyof ScatterProps]: boolean } = {
+  xs: true,
+  ys: true,
+  color: true,
+  onClick: false,
+}
+// Property 'onDoubleClick' is missing in type '{ xs: true; ys: true; color: true; onClick: false; }' but required in type '{ xs: boolean; ys: boolean; color: boolean; onClick: boolean; onDoubleClick: boolean; }'.
+// onDoubleClick 속성을 추가하라고 에러가 뜬다.
+```

--- a/chapter2/lado/item9-11.md
+++ b/chapter2/lado/item9-11.md
@@ -1,0 +1,129 @@
+# 이펙티브 타입스크립트 아이템 9~11
+
+## 아이템 9. 타입 단언보다는 타입 선언을 사용하기
+
+```tsx
+const alice: Person = { name: 'Alice' } // 타입 선언
+const bob = { name: 'Bob' } as Person // 타입 단언
+```
+
+- 타입 선언은 할당되는 값이 해당 인터페이스를 만족하는지 검사한다. 반면, 타입 단언은 강제로 타입을 지정했으니 타입 체커에게 오류를 무시하라고 하는 것이다.
+- 타입 단언이 꼭 필요한 경우가 아니라면, 안전성 체크도 되는 타입 선언을 사용하는 것이 좋다.
+- 타입 단언이 꼭 필요한 경우
+  - (ex) DOM 엘리먼트
+    ```tsx
+    document.querySelector('#myButton').addEventListener('click', (e) => {
+      e.currentTarget // 타입은 EventTarget
+      const button = e.currentTarget as HTMLButtonElement
+      button // 타입은 HTMLButtonElement
+    })
+    ```
+    - 타입스크립트는 DOM에 접근할 수 없기 때문에 #myButton이 버튼 엘리먼트인지 알지 못한다. 우리는 타입스크립트가 알지 못하는 정보를 가지고 있기 때문에 여기서는 타입 단언문을 쓰는 것이 타당하다.
+- 접미사로 쓰이는 `!` 는 null이 아니라는 단언문으로 해석
+- 모든 타입은 unknown의 서브타입이기 때문에 unknown이 포함된 단언문은 항상 동작한다. 하지만 unknown을 사용한 이상 적어도 무언가 위험한 동작을 하고 있다는 걸 알 수 있다.
+  ```tsx
+  const el = document.body as unknown as Person
+  ```
+- 화살표 함수의 반환 타입 선언하기
+  ```tsx
+  const people: Person[] = ['alice', 'bob', 'jan'].map((name): Person => ({ name }))
+  ```
+
+<br />
+
+## 아이템 10. 객체 래퍼 타입 피하기
+
+- 자바스크립트에는 메서드를 가지는 String ‘객체’ 타입이 정의되어 있다. string ‘기본형’에는 메서드가 없지만, string 기본형에 charAt 같은 메서드를 사용할 때, 자바스크립트는 기본형을 String 객체로 래핑하고 메서드를 호출하고 마지막에 래핑한 객체를 버린다.
+  ```tsx
+  > x = "hello"
+  > x.language = 'English'
+  'English' // x가 String 객체로 변환된 후 language 속성 추가
+  > x.language
+  undefined // language 속성이 추가된 객체 버려짐
+  ```
+  - (cf) 몽키-패치(monkey-patch): 런타임에 프로그램의 어떤 기능을 수정해서 사용하는 기법. 자바스크립트에서는 주로 프로토타입을 변경하는 것이 이에 해당.
+- 타입스크립트는 기본형과 객체 래퍼 타입을 별도로 모델링한다.
+- string을 String으로 잘못 타이핑하지 않도록 주의해야 한다.
+  - string을 매개변수로 받는 메서드에 String 객체를 전달하는 순간 문제가 발생한다.
+    ```tsx
+    function isGreeting(phrase: String) {
+      return ['hello', 'good day'].includes(phrase)
+      // Argument of type 'String' is not assignable to parameter of type 'string'.
+      // 'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+    }
+    ```
+  - string은 String에 할당할 수 있지만 String은 string에 할당할 수 없다.
+- 기본형 타입은 객체 래퍼에 할당할 수 있기 때문에 타입스크립트는 기본형 타입을 객체 래퍼에 할당하는 선언을 허용한다. 하지만 오해하기 쉽기 때문에 기본형 타입을 사용하는 것이 낫다.
+  - new 없이 BigInt와 Symbol을 호출하는 경우는 기본형을 생성하기 때문에 사용해도 좋다.
+
+<br />
+
+## 아이템 11. 잉여 속성 체크의 한계 인지하기
+
+- 타입이 명시된 변수에 객체 리터럴을 할당할 때 타입스크립트는 해당 타입의 속성이 있는지, 그리고 ‘그 외의 속성은 없는지’ 확인한다.
+- 잉여 속성 체크가 할당 가능 검사와는 별도의 과정이라는 것을 알아야 타입스크립트 타입 시스템에 대한 개념을 정확히 잡을 수 있다.
+- 아래의 예제에서는 구조적 타입 시스템에서 발생할 수 있는 중요한 종류의 오류를 잡을 수 있도록 ‘잉여 속성 체크’라는 과정이 수행되었다.
+
+  ```tsx
+  interface Room {
+    numDoors: number
+    ceilingHeightFt: number
+  }
+
+  const r: Room = {
+    numDoors: 1,
+    ceilingHeightFt: 10,
+    elephant: 'present',
+    // Type '{ numDoors: number; ceilingHeightFt: number; elephant: string; }' is not assignable to type 'Room'.
+    // Object literal may only specify known properties, and 'elephant' does not exist in type 'Room'
+  }
+  ```
+
+- 통상적인 할당 가능 검사에서는 obj가 Room 타입의 부분 집합을 포함하므로 에러가 발생하지 않는다.
+
+  ```tsx
+  interface Room {
+    numDoors: number
+    ceilingHeightFt: number
+  }
+
+  const obj = {
+    numDoors: 1,
+    ceilingHeightFt: 10,
+    elephant: 'present',
+  }
+
+  const r: Room = obj
+  ```
+
+- 엄격한 객체 리터럴 체크
+  - 객체 리터럴을 변수에 할당하거나 함수에 매개변수로 전달할 때 잉여 속성 체크가 수행된다.
+  - 잉여 속성 체크를 이용하면 타입 시스템의 구조적 본질을 해치지 않으면서도 객체 리터럴에 알 수 없는 속성을 허용하지 않음으로써 속성 이름의 오타 같은 실수를 잡을 수 있다.
+  - 객체 리터럴이 아닌 경우, 잉여 속성 체크가 적용되지 않는다. 즉, 임시 변수를 도입하면 잉여 속성 체크를 건너뛸 수 있다.
+  - 타입 단언문을 사용할 때에도 잉여 속성 체크가 적용되지 않는다.
+  - 객체 리터럴을 변수에 할당할 때, 잉여 속성 체크를 회피하는 방법
+    - 인덱스 시그니처를 통해 추가적인 속성 예상하기 <- 과연 이것은 적절한 방법일까..?
+    ```tsx
+    interface Options {
+      darkMode?: boolean
+      [otherOptions: string]: unknown
+    }
+    const o: Options = { darkmode: true } // 정상
+    ```
+- 선택적 속성만 가지는 ‘약한’ 타입
+
+  - 모든 속성이 선택적인 타입은 구조적 관점에서 모든 객체를 포함할 수 있다. 이런 약한 타입에 대해서 타입스크립트는 값 타입과 선언 타입에 공통된 속성이 있는지 확인하는 별도의 체크를 수행한다.
+  - 잉여 속성 체크와 마찬가지로 오타를 잡는 데 효과적이다.
+  - 잉여 속성 체크와 다르게, 약한 타입과 관련된 할당문마다 수행된다. 임시 변수를 제거하더라도 공통 속성 체크는 여전히 동작한다. **← ⁇⁇⁇**
+
+  ```tsx
+  interface LineChartOptions {
+    logscale?: boolean
+    invertedYAxis?: boolean
+    areaChart?: boolean
+  }
+
+  const opts = { logScale: true }
+  const o: LineChartOptions = opts
+  // Type '{ logScale: boolean; }' has no properties in common with type 'LineChartOptions'.
+  ```


### PR DESCRIPTION
2장 끝까지 오시느라 모두 수고 많으셨습니다! 👏
스터디 중 나온 이야기들을 옐님과 제가 간략하게 정리해둔 게 있는데 공유하면 좋을 듯 싶어 올려볼게요.

<br />

# 아이템 9~11 (2022.04.14)

- 배열에 대해서 find 메소드를 쓰려고 하는데, 배열에 undefined가 들어오는 경우가 있어서 타입 단언을 써서 주로 해결... 하지만 타입 단언을 안 쓰고 해결할 수 있을까...???

```tsx
const map = new Map([["me", 1000]])
const age = map.get("me"); // 타입은 number | undefined
```

- null & undefined 회피 방법

```jsx
// 1.
if (age === undefined) {
	throw Error("test")
}
age // undefined가 아닌 값만 걸러진다

// 2.
if (!age) return null

// 3.
age || 0

// 4. ?? 널 병합 연산자는 falsy 값 제외
const data = { success: false, display: "에러 메시지" }
data.display ?? "에러 없음"
```

- cf) **suspense: 리액트 18에 도입,** Vue3에 있는 개념. suspense 컴포넌트는 데이터가 받아와지지 않는 동안 컴포넌트가 렌더링되지 않는 개념인듯?
- 구조적 타이핑이란? 모양만 맞으면 그게 그거다. 덕 타이핑이라고도 함. 꽥꽥 우는 메소드가 있으면 오리라고 간주한다.

```tsx
type Person = {
	name: string
}

const a = {
	name: "yap",
	age: 1000
}

const b: Person = a; // 정상. 근데 age 속성 못 써도 괜찮지?
b.age // 에러. 쉐도잉 현상이라고도 부름. Person 이외의 속성을 지움.

// 타입이 명시된 변수에 객체 리터럴을 할당할 때
const a2: Person = {
	name: "yap",
	age: 1000 // 에러남
}

// 함수의 parameter의 타입을 Person으로 명시
function callYourName(p: Person) {
	console.log(p.name);
}

const person = {
	name: "yap",
	age: 1000
}

callYourName(person) // 정상.
callYourName({ name: "yap", age: 1000 }) // 에러. age 없다구~~
```

- 쉐도잉은 의도적인 동작. 객체 지향의 관점에서 type에 정의하지 않은 속성을 쓰는 것은 감추는 것이라고 인식한다.
    - type으로 정의한 것은 public 변수, type에 선언되지 않은 값은 private 변수와 같은 것이라고 이해하면 이해하기 좋다!
- 속성이 많아질 수록 좁은 타입
    - (ex) 사람 속성을 가진 사람보다 사람, 남자, 아시안, 한국인 속성을 가진 사람이 훨씬 적다
    
    ```jsx
    a: 사람 = 남자
    b: 남자 = 사람 <- ERROR!
    ```
    
- 함수를 만들 때는 필요한 property만 요청해서 입력은 넓게, 리턴할 때는 좁은 타입만 반환하는 게 좋다!!

<br />

# 아이템 12~14 (2022.04.21)

### 함수표현식? 함수선언문?

팀에서 사용하는 컨벤션에 따라 쓰는 경우가 대부분이지 않을까. 에어비앤비에서는 리액트 컴포넌트를 만들 때는 함수선언문으로, 매개변수를 받는 함수의 경우는 함수표현식으로 쓴다고 한다. 

### `interface`를 사용할 때 사용하는 **선언병합**의 경우 실수를 두 번 했을 때 에러를 내지 않아서 위험한 것은 아닌지

책에서 선언병합으로 쓰인 예시를 든 것 역시 보강이 필요한 프로젝트의 경우였다. 예를 들어, `Array` 인터페이스는 이미 정의되어 있고, 새로운 `find`와 같은 메서드를 포함하려고 할 경우 tsconfig.json의 lib 목록에 추가하면 타입스크립트는 선언된 인터페이스를 병합하는 형식.

책에서도 언급했듯이 타입과 인터페이스의 차이점과 비슷한 점을 이해하며 사용하자.

### 제네릭은 뭘까

제네릭 타입은 타입을 위한 함수와 같은 것, [유틸리티 타입](https://typescript-kr.github.io/pages/utility-types.html)

`Record<K, T>` 

```tsx
type Grade = '1' | '2' | '3';
type Score = 'A' | 'B' | 'C';

const score = Record<Grade, Score> = {
  1: 'A',
  2: 'C',
  3: 'B',
}

type Person = 'kim' | 'park' | 'lim';
type PageInfo = {title: Person}
type Page = 'home' | 'about' | 'contact';

const x: Record<Page, PageInfo> = {
    about: { title: 'kim' },
    contact: { title: 'park' },
    home: { title: 'lim' },
};
```

[조건부타입(Conditional Type)](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) 

```tsx
interface IdLabel {
  id: number /* some fields */;
}
interface NameLabel {
  name: string /* other fields */;
}

// 제네릭타입을 제한하려면 extends를 사용하면 된다.
type NameOrId<T extends number | string> = T extends number 
  ? IdLabel
  : NameLabel;

const a: NameOrId<number | string> = {
  id: 12,
  name: "12"
}
```

<br />

# 아이템 15~18 (2022.04.28)

### `Record< 'x' & 'y', string >` 와 같은 방식으로 쓸 수는 없을까?

- 쓰지 말자

```tsx
const xy: Record<'x' & 'y', string> = {}
// xy의 타입은 Record<never, string>
```

### `const`와 `readonly` 의 차이

- 타입 시스템에서 readonly를 사용하면, property 변경에 대해 더 안전하게 코딩할 수 있다.

```tsx
/************ const의 경우 ************/

const me = {
    name: "익명"
}

me = { name: "나" } // 에러: Cannot assign to 'me' because it is a constant.
me.name = "나" // 정상
console.log(me) // { name: "나" }

/************ readonly가 아닌 타입 선언의 경우 ************/

type UpdatableMe = {
    name: string
}

const updatableMe: UpdatableMe = {
    name: "익명"
}

updatableMe.name = "나" // 정상
console.log(updatableMe) // { name: "나" }

/************ readonly를 적용한 타입 선언의 경우 ************/

type ReadonlyMe = {
    readonly name: string
}

const readonlyMe: ReadonlyMe = {
    name: "익명"
}

readonlyMe.name = "나" // 에러: Cannot assign to 'name' because it is a read-only property.
```

- const로 선언한 배열은 `Array.prototype.push` 로 값 변경이 가능하지만 readonly를 적용한 배열은 값 변경 불가.

```tsx
/************ const의 경우 ************/
const fruit = ["apple", "lemon"]

fruit.push("grape")
console.log(fruit) // ["apple", "lemon", "grape"]

/************ readonly를 적용한 타입 선언의 경우 ************/

type Fruit = readonly string[]
const readonlyFruit: Fruit = ["apple", "lemon"]

readonlyFruit.push("grape") // 에러: Property 'push' does not exist on type 'Fruit'.
```

### 튜플이란?

각 요소마다 타입이 정해져 있고, 요소의 개수가 정해져 있는 배열

```tsx
const nameAndAgeAndIsHappy: [string, number, boolean] = ['익명', 365, true]
```

### ArrayLike란?

- 자바스크립트의 유사 배열
    - 배열이 아닌데 배열인 척 하는 객체
    - 숫자 인덱스로 값 접근 O `arrayLike[1]`
    - length 프로터피 값 접근 O `arrayLike.length`
    - for문 O
    - for...of문, 비구조화 할당, 스프레드 연산자 사용 X
    - Array.prototype 메소드 사용 X `arrayLike.map`
- 유사 배열의 조건
    1. 인덱스를 key로 하는 속성이 있는 객체여야 한다.
    2. length 속성이 있어야 한다.
- HTMLCollection, arguments 등이 유사배열에 해당한다.

```tsx
interface ArrayLike<T> {
    readonly length: number;
    readonly [n: number]: T;
}

const tupleLike: ArrayLike<string> = {
    0: 'A',
    1: 'B',
    length: 2,
}

// 타입스크립트 ArrayLike 타입은 인덱스를 number 타입으로 정의하고 있지만
// 실제 자바스크립트 런타임에서 인덱스는 string이다.
```

(번외) 유사 배열을 스프레드 연산자를 사용하려면 이터러블 객체로 만들어야 한다.

```tsx
const tupleLike = {
    0: 'A',
    1: 'B',
    length: 2,
    [Symbol.iterator]() { 
        this.i = 0; 
        return this; 
    },
    next() { 
        return { 
            value: this[this.i], 
            done: ++this.i > this.length 
        }; 
    }
}

const iterableTupleLike = [...tupleLike]
console.log(iterableTupleLike) // ["A", "B"]
```

### ‘매핑된 타입을 사용하여 값을 동기화하기’라는 말은 무슨 말인가?

- 원본 타입에서 파생된 타입인 경우, 원본 타입의 property가 변경될 때마다 파생된 타입의 property를 원본 타입에 맞춰 변경하라는 에러를 띄우게끔 파생 타입의 property를 강제하는 것이 좋다. 이를 위해 `[k in keyof 원본 타입]` 와 같은 매핑된 타입을 사용해 원본 타입과 파생된 타입이 연동되도록 코딩하라는 뜻.
